### PR TITLE
Use compiled shortcode name for callback

### DIFF
--- a/src/Brouwers/Shortcodes/Compilers/ShortcodeCompiler.php
+++ b/src/Brouwers/Shortcodes/Compilers/ShortcodeCompiler.php
@@ -117,13 +117,14 @@ class ShortcodeCompiler {
     {
         // Compile the shortcode
         $compiled = $this->compileShortcode($matches);
+        $name = $compiled->getName();
 
         // Render the shortcode through the callback
-        return call_user_func_array($this->getCallback(), array(
+        return call_user_func_array($this->getCallback($name), array(
             $compiled,
             $compiled->getContent(),
             $this,
-            $compiled->getName()
+            $name
         ));
     }
 
@@ -180,10 +181,10 @@ class ShortcodeCompiler {
      * @param  string  $name
      * @return callable|array
      */
-    public function getCallback()
+    public function getCallback($name)
     {
         // Get the callback from the shortcodes array
-        $callback = $this->registered[$this->getName()];
+        $callback = $this->registered[$name];
 
         // if is a string
         if(is_string($callback))


### PR DESCRIPTION
Fixes problem when several shortcodes pass through the same registered callback.

This code was making problems
```php
  $shortcode->register('text', function($shortcode, $content, $compiler, $name)
  {
    echo "We are here";
    return '<div '. $shortcode->get('class', $shortcode->class) .'>' . $content . '</div>';
  });

  $shortcode->register('row', function($shortcode, $content, $compiler, $name)
  {
    return '<div '. $shortcode->get('class', 'row') .'>' . $content . '</div>';
  });
```