### PR TITLE
Few changes for Laravel 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - hhvm

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,10 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0"
+        "illuminate/view": "~5.2",
+        "illuminate/support": "~5.2",
+        "illuminate/contracts": "~5.2",
+        "php" : "~5.5|~7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/src/Brouwers/Shortcodes/Compilers/ShortcodeCompiler.php
+++ b/src/Brouwers/Shortcodes/Compilers/ShortcodeCompiler.php
@@ -1,6 +1,6 @@
 <?php namespace Brouwers\Shortcodes\Compilers;
 
-use Str;
+use Illuminate\Support\Str;
 
 class ShortcodeCompiler {
 

--- a/src/Brouwers/Shortcodes/Illuminate/View/View.php
+++ b/src/Brouwers/Shortcodes/Illuminate/View/View.php
@@ -3,11 +3,11 @@
 use ArrayAccess;
 use Closure;
 use Illuminate\Support\MessageBag;
+use Illuminate\Contracts\Support\Renderable;
 use Illuminate\View\View as IlluminateView;
 use Illuminate\View\Engines\EngineInterface;
 use Brouwers\Shortcodes\Compilers\ShortcodeCompiler;
 use Illuminate\Support\Contracts\ArrayableInterface as Arrayable;
-use Illuminate\Support\Contracts\RenderableInterface as Renderable;
 
 class View extends IlluminateView implements ArrayAccess, Renderable {
 

--- a/src/Brouwers/Shortcodes/ShortcodesServiceProvider.php
+++ b/src/Brouwers/Shortcodes/ShortcodesServiceProvider.php
@@ -10,7 +10,6 @@ class ShortcodesServiceProvider extends ServiceProvider {
 
 	/**
 	 * Boot the package
-	 * @return [type] [description]
 	 */
 	public function boot()
 	{
@@ -19,7 +18,6 @@ class ShortcodesServiceProvider extends ServiceProvider {
 
 	/**
 	 * Enable the compiler
-	 * @return [type] [description]
 	 */
 	public function enableCompiler()
 	{
@@ -45,7 +43,6 @@ class ShortcodesServiceProvider extends ServiceProvider {
 
 	/**
 	 * Register short code compiler
-	 * @return [type] [description]
 	 */
 	public function registerShortcodeCompiler()
 	{
@@ -57,7 +54,6 @@ class ShortcodesServiceProvider extends ServiceProvider {
 
 	/**
 	 * Register the shortcode
-	 * @return [type] [description]
 	 */
 	public function registerShortcode()
 	{
@@ -68,7 +64,6 @@ class ShortcodesServiceProvider extends ServiceProvider {
 
 	/**
 	 * Register Laravel view
-	 * @return [type] [description]
 	 */
 	public function registerView()
 	{

--- a/src/Brouwers/Shortcodes/ShortcodesServiceProvider.php
+++ b/src/Brouwers/Shortcodes/ShortcodesServiceProvider.php
@@ -14,7 +14,6 @@ class ShortcodesServiceProvider extends ServiceProvider {
 	 */
 	public function boot()
 	{
-		$this->package('brouwers/shortcodes');
 		$this->enableCompiler();
 	}
 
@@ -50,7 +49,7 @@ class ShortcodesServiceProvider extends ServiceProvider {
 	 */
 	public function registerShortcodeCompiler()
 	{
-		$this->app->bindShared('shortcode.compiler', function($app)
+		$this->app->singleton('shortcode.compiler', function($app)
 		{
 			return new ShortcodeCompiler();
 		});
@@ -62,7 +61,7 @@ class ShortcodesServiceProvider extends ServiceProvider {
 	 */
 	public function registerShortcode()
 	{
-		$this->app->bindShared('shortcode', function($app) {
+		$this->app->singleton('shortcode', function($app) {
 			return new Shortcode($app['shortcode.compiler']);
 		});
 	}
@@ -73,7 +72,7 @@ class ShortcodesServiceProvider extends ServiceProvider {
 	 */
 	public function registerView()
 	{
-		$this->app->bindShared('view', function($app)
+		$this->app->singleton('view', function($app)
 		{
 			// Next we need to grab the engine resolver instance that will be used by the
 			// environment. The resolver will be used by an environment to get each of


### PR DESCRIPTION
I just changed a two old class references from Laravel 4.2 to Laravel 5.x

ShortcodesServiceProvider.php
OLD: bindShare
NEW: singleton

View.php
OLD: use Illuminate\Support\Contracts\RenderableInterface as Renderable
NEW: use Illuminate\Contracts\Support\Renderable;
